### PR TITLE
Feature/admin/role assignment

### DIFF
--- a/src/main/java/com/ian/novelviewer/admin/application/AdminService.java
+++ b/src/main/java/com/ian/novelviewer/admin/application/AdminService.java
@@ -1,0 +1,44 @@
+package com.ian.novelviewer.admin.application;
+
+import com.ian.novelviewer.user.dto.UserDto;
+import com.ian.novelviewer.common.exception.CustomException;
+import com.ian.novelviewer.user.domain.User;
+import com.ian.novelviewer.user.domain.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.ian.novelviewer.common.enums.Role.ROLE_AUTHOR;
+import static com.ian.novelviewer.common.exception.ErrorCode.ALREADY_HAS_ROLE;
+import static com.ian.novelviewer.common.exception.ErrorCode.USER_NOT_FOUND;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserDto.RoleApprovalResponse approveRole(String userId, UserDto.RoleApprovalRequest request) {
+        log.info("작가 권한 승인 요청 처리 - 신청자: {}", userId);
+        User user = userRepository.findByLoginId(userId)
+                .orElseThrow(() -> {
+                    log.warn("작가 등록 실패 - 존재하지 않는 사용자: {}", userId);
+                    return new CustomException(USER_NOT_FOUND);
+                });
+
+        if (user.getRoles().contains(ROLE_AUTHOR)) {
+            log.warn("작가 등록 실패 - 이미 등록된 작가: {}", userId);
+            throw new CustomException(ALREADY_HAS_ROLE);
+        }
+
+        user.addAuthorName(request.getNickname());
+        user.addRole(ROLE_AUTHOR);
+
+        log.info("작가 권한 승인 완료");
+
+        return UserDto.RoleApprovalResponse.from(user);
+    }
+}

--- a/src/main/java/com/ian/novelviewer/admin/ui/AdminController.java
+++ b/src/main/java/com/ian/novelviewer/admin/ui/AdminController.java
@@ -1,0 +1,33 @@
+package com.ian.novelviewer.admin.ui;
+
+import com.ian.novelviewer.admin.application.AdminService;
+import com.ian.novelviewer.user.dto.UserDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/approve-role/{userId}")
+    public ResponseEntity<?> approveRole(
+            @PathVariable String userId,
+            @RequestBody @Valid UserDto.RoleApprovalRequest request,
+            Authentication authentication
+    ) {
+        log.info("작가 권한 승인 요청 수신 - 신청자: {}, 관리자: {}", userId, authentication.getName());
+        UserDto.RoleApprovalResponse response = adminService.approveRole(userId, request);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/ian/novelviewer/common/config/SecurityConfig.java
+++ b/src/main/java/com/ian/novelviewer/common/config/SecurityConfig.java
@@ -2,7 +2,6 @@ package com.ian.novelviewer.common.config;
 
 import com.ian.novelviewer.common.security.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;

--- a/src/main/java/com/ian/novelviewer/common/exception/ErrorCode.java
+++ b/src/main/java/com/ian/novelviewer/common/exception/ErrorCode.java
@@ -8,7 +8,9 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     INVALID_CREDENTIALS("아이디 또는 비밀번호가 잘못되었습니다.", HttpStatus.UNAUTHORIZED),
     DUPLICATE_LOGIN_ID("이미 사용 중인 아이디입니다.", HttpStatus.CONFLICT),
-    DUPLICATE_EMAIL("이미 가입된 이메일입니다.", HttpStatus.CONFLICT);
+    DUPLICATE_EMAIL("이미 가입된 이메일입니다.", HttpStatus.CONFLICT),
+    USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ALREADY_HAS_ROLE("이미 해당 권한을 보유하고 있습니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/ian/novelviewer/user/domain/User.java
+++ b/src/main/java/com/ian/novelviewer/user/domain/User.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -37,6 +36,15 @@ public class User extends BaseEntity {
     private List<Role> roles = new ArrayList<>();
 
     public void encodingPassword(String encodedPassword) {
-        this.password = encodedPassword;
+        password = encodedPassword;
+    }
+
+    public void addAuthorName(String authorName) {
+        nickname = authorName;
+    }
+
+    public void addRole(Role role) {
+        if (!roles.contains(role))
+            roles.add(role);
     }
 }

--- a/src/main/java/com/ian/novelviewer/user/dto/UserDto.java
+++ b/src/main/java/com/ian/novelviewer/user/dto/UserDto.java
@@ -1,0 +1,43 @@
+package com.ian.novelviewer.user.dto;
+
+import com.ian.novelviewer.common.enums.Role;
+import com.ian.novelviewer.user.domain.User;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class UserDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RoleApprovalRequest {
+
+        @NotBlank(message = "작가명을 입력해주세요.")
+        private String nickname;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RoleApprovalResponse {
+
+        private String loginId;
+        private String nickname;
+        private List<Role> roles;
+
+        public static UserDto.RoleApprovalResponse from(User user) {
+            return RoleApprovalResponse.builder()
+                    .loginId(user.getLoginId())
+                    .nickname(user.getNickname())
+                    .roles(user.getRoles().stream().toList())
+                    .build();
+        }
+    }
+}

--- a/src/test/java/com/ian/novelviewer/admin/application/AdminServiceTest.java
+++ b/src/test/java/com/ian/novelviewer/admin/application/AdminServiceTest.java
@@ -1,0 +1,111 @@
+package com.ian.novelviewer.admin.application;
+
+import com.ian.novelviewer.user.dto.UserDto;
+import com.ian.novelviewer.common.exception.CustomException;
+import com.ian.novelviewer.common.exception.ErrorCode;
+import com.ian.novelviewer.user.domain.User;
+import com.ian.novelviewer.user.domain.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.ian.novelviewer.common.enums.Role.ROLE_AUTHOR;
+import static com.ian.novelviewer.common.enums.Role.ROLE_USER;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @InjectMocks
+    AdminService adminService;
+
+    @Mock
+    UserRepository userRepository;
+
+    User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .loginId("testId")
+                .password("encodedTestPassword")
+                .email("test@example.com")
+                .realname("테스트")
+                .roles(new ArrayList<>(List.of(ROLE_USER)))
+                .build();
+    }
+
+    @Test
+    @DisplayName("권한 부여 성공")
+    void approve_success() {
+        // given
+        String userId = "testId";
+
+        UserDto.RoleApprovalRequest request = UserDto.RoleApprovalRequest.builder()
+                .nickname("테스트닉네임")
+                .build();
+
+        when(userRepository.findByLoginId(userId))
+                .thenReturn(Optional.of(user));
+
+        // when
+        UserDto.RoleApprovalResponse response = adminService.approveRole(userId, request);
+
+        // then
+        assertThat(response.getLoginId()).isEqualTo(userId);
+        assertThat(response.getNickname()).isEqualTo("테스트닉네임");
+        assertThat(response.getRoles()).contains(ROLE_AUTHOR);
+    }
+
+    @Test
+    @DisplayName("권한 부여 실패 - 존재하지 않는 사용자")
+    void approve_fail_user_not_found() {
+        // given
+        UserDto.RoleApprovalRequest request = UserDto.RoleApprovalRequest.builder()
+                .nickname("테스트닉네임")
+                .build();
+
+        when(userRepository.findByLoginId("notFound"))
+                .thenReturn(Optional.empty());
+
+        // when
+        Throwable thrown = catchThrowable(() -> adminService.approveRole("notFound", request));
+
+        // that
+        assertThat(thrown).isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("권한 부여 실패 - 이미 권한이 존재")
+    void approve_fail_already_has_role() {
+        // given
+        String userId = "testId";
+        user.addRole(ROLE_AUTHOR);
+
+        UserDto.RoleApprovalRequest request = UserDto.RoleApprovalRequest.builder()
+                .nickname("테스트닉네임")
+                .build();
+
+        when(userRepository.findByLoginId(userId))
+                .thenReturn(Optional.of(user));
+
+        // when
+        Throwable thrown = catchThrowable(() -> adminService.approveRole(userId, request));
+
+        // then
+        assertThat(thrown).isInstanceOf(CustomException.class)
+                .extracting(e -> ((CustomException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ALREADY_HAS_ROLE);
+    }
+}


### PR DESCRIPTION
## 🛡️ 작가 권한 부여 API 기능 구현 
관리자가 특정 사용자에게 작가 권한(`ROLE_AUTHOR`)을 부여할 수 있는 기능을 구현했습니다.
요청 받은 신청자 아이디와 작가 명을 기준으로 필명 설정 및 권한을 부여하며, 이미 권한이 있는 경우 예외를 발생시킵니다.
단위 테스트를 통해 성공 및 실패 케이스를 검증했습니다.

<br>

---

### ✅ 주요 구현 내용
- `AdminController`
    - `Post /admin/approve-role/{userId}`: 작가 권한 부여 요청 API
- `AdminService`
    - 사용자 조회 및 존재 여부 확인
    - 작가 권한(`ROLE_AUTHOR`) 보유 여부 검증
    - 필명 설정 및 작가 권한 추가
    - 권한 부여 후 응답 DTO 반환
- `UserDto`
    - `RoleApprovalRequest`: 작가 권한 부여 요청 DTO
        - 닉네임(필명) 입력
        - 유효성 검증 애너테이션 포함
    - `RoleApprovalResponse`: 작가 권한 부여 응답 DTO
        - 로그인 ID, 닉네임, 권한 목록 반환
- `User`
    - 닉네임 등록 메서드 추가
    - 권한 부여 메서드 추가
- `AdminServiceTest` (단위 테스트)
    - 작가 권한 부여 성공 및 실패 케이스 검증
- ErrorCode
    - 커스텀 예외 에러 코드 추가
    - 존재하지 않는 사용자 → `USER_NOT_FOUND`  
    - 이미 권한 존재 → `ALREADY_HAS_ROLE`

<br>

---

### 🔧 변경 사항
**AS-IS**
권한 승인 로직 부재 및 작가 권한 부여 API 미구현으로 작가 권한을 부여할 수 없음

<br>

**TO-BE**
관리자 계정에서 사용자에게 관리자 권한을 부여할 수 있음

<br>

---

### 🧪 테스트
- [x] **테스트 코드**
- `AdminServiceTest` 단위 테스트 작성
    - `approve_success()`: 권한 부여 성공
    - `approve_fail_user_not_found()`: 존재하지 않는 사용자
    - `approve_fail_already_has_role()`: 이미 권한이 있는 경우
- [x] **API 테스트**
- `/admin/approve-role/{userId}` 수동 테스트 (Postman)