### PR TITLE
Feature/novel/create

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    implementation 'software.amazon.awssdk:s3:2.31.37'
 
     compileOnly 'org.projectlombok:lombok'
 

--- a/src/main/java/com/ian/novelviewer/common/config/S3Config.java
+++ b/src/main/java/com/ian/novelviewer/common/config/S3Config.java
@@ -1,0 +1,41 @@
+package com.ian.novelviewer.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.region.static}")
+    String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/com/ian/novelviewer/common/exception/ErrorCode.java
+++ b/src/main/java/com/ian/novelviewer/common/exception/ErrorCode.java
@@ -10,7 +10,10 @@ public enum ErrorCode {
     DUPLICATE_LOGIN_ID("이미 사용 중인 아이디입니다.", HttpStatus.CONFLICT),
     DUPLICATE_EMAIL("이미 가입된 이메일입니다.", HttpStatus.CONFLICT),
     USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    ALREADY_HAS_ROLE("이미 해당 권한을 보유하고 있습니다.", HttpStatus.BAD_REQUEST);
+    ALREADY_HAS_ROLE("이미 해당 권한을 보유하고 있습니다.", HttpStatus.BAD_REQUEST),
+    S3_UPLOAD_FAILED("이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    S3_ROLLBACK_FAILED("이미지 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    NOVEL_CREATION_FAILED("작품 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/ian/novelviewer/novel/application/NovelService.java
+++ b/src/main/java/com/ian/novelviewer/novel/application/NovelService.java
@@ -20,15 +20,15 @@ public class NovelService {
 
     @Transactional
     public NovelDto.NovelInfoResponse createNovel(
-            NovelDto.CreateNovelRequest request, String imageKey, CustomUserDetails user
+            NovelDto.CreateNovelRequest request, CustomUserDetails user
     ) {
         Long contentId = generateContentId();
 
         Novel novel = novelRepository.save(
                 Novel.builder()
                         .contentId(contentId)
-                        .thumbnail(imageKey)
                         .title(request.getTitle())
+                        .thumbnail(request.getThumbnailKey())
                         .description(request.getDescription())
                         .category(request.getCategory())
                         .author(user.getUser())

--- a/src/main/java/com/ian/novelviewer/novel/application/NovelService.java
+++ b/src/main/java/com/ian/novelviewer/novel/application/NovelService.java
@@ -1,0 +1,46 @@
+package com.ian.novelviewer.novel.application;
+
+import com.ian.novelviewer.common.security.CustomUserDetails;
+import com.ian.novelviewer.novel.domain.Novel;
+import com.ian.novelviewer.novel.domain.NovelRepository;
+import com.ian.novelviewer.novel.dto.NovelDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NovelService {
+
+    private final NovelRepository novelRepository;
+
+    @Transactional
+    public NovelDto.NovelInfoResponse createNovel(
+            NovelDto.CreateNovelRequest request, String imageKey, CustomUserDetails user
+    ) {
+        Long contentId = generateContentId();
+
+        Novel novel = novelRepository.save(
+                Novel.builder()
+                        .contentId(contentId)
+                        .thumbnail(imageKey)
+                        .title(request.getTitle())
+                        .description(request.getDescription())
+                        .category(request.getCategory())
+                        .author(user.getUser())
+                        .build()
+        );
+
+        return NovelDto.NovelInfoResponse.from(novel);
+    }
+
+    private Long generateContentId() {
+        UUID uuid = UUID.randomUUID();
+
+        return Math.abs(uuid.getMostSignificantBits());
+    }
+}

--- a/src/main/java/com/ian/novelviewer/novel/application/S3Service.java
+++ b/src/main/java/com/ian/novelviewer/novel/application/S3Service.java
@@ -1,0 +1,66 @@
+package com.ian.novelviewer.novel.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    private static final Duration PRESIGNED_URL_DURATION = Duration.ofMinutes(30);
+
+    @Value("${spring.cloud.aws.bucket}")
+    private String bucket;
+
+    public String upload(MultipartFile file, String folderName) throws IOException {
+        log.info("이미지 업로드 요청 처리 - 파일명: {}, 폴더명: {}", file.getOriginalFilename(), folderName);
+
+        String fileName = folderName + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
+        log.info("file name: {}", fileName);
+
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .contentType(file.getContentType())
+                .build();
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes()));
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .build();
+
+        PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(
+                builder -> builder.getObjectRequest(getObjectRequest)
+                        .signatureDuration(PRESIGNED_URL_DURATION)
+        );
+
+        return presignedRequest.url().toString();
+    }
+
+    public void delete(String key) throws IOException {
+        s3Client.deleteObject(DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build());
+    }
+}

--- a/src/main/java/com/ian/novelviewer/novel/application/S3Service.java
+++ b/src/main/java/com/ian/novelviewer/novel/application/S3Service.java
@@ -1,5 +1,6 @@
 package com.ian.novelviewer.novel.application;
 
+import com.ian.novelviewer.novel.dto.NovelDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,7 +31,7 @@ public class S3Service {
     @Value("${spring.cloud.aws.bucket}")
     private String bucket;
 
-    public String upload(MultipartFile file, String folderName) throws IOException {
+    public NovelDto.ThumbnailResponse upload(MultipartFile file, String folderName) throws IOException {
         log.info("이미지 업로드 요청 처리 - 파일명: {}, 폴더명: {}", file.getOriginalFilename(), folderName);
 
         String fileName = folderName + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
@@ -54,7 +55,11 @@ public class S3Service {
                         .signatureDuration(PRESIGNED_URL_DURATION)
         );
 
-        return presignedRequest.url().toString();
+        NovelDto.ThumbnailResponse thumbnailKey = NovelDto.ThumbnailResponse.builder()
+                .thumbnailKey(presignedRequest.url().toString())
+                .build();
+
+        return thumbnailKey;
     }
 
     public void delete(String key) throws IOException {

--- a/src/main/java/com/ian/novelviewer/novel/domain/Category.java
+++ b/src/main/java/com/ian/novelviewer/novel/domain/Category.java
@@ -1,0 +1,8 @@
+package com.ian.novelviewer.novel.domain;
+
+public enum Category {
+    FANTASY,
+    ROMANCE,
+    MARTIAL_ARTS,
+    BL
+}

--- a/src/main/java/com/ian/novelviewer/novel/domain/Novel.java
+++ b/src/main/java/com/ian/novelviewer/novel/domain/Novel.java
@@ -1,0 +1,35 @@
+package com.ian.novelviewer.novel.domain;
+
+import com.ian.novelviewer.common.base.BaseEntity;
+import com.ian.novelviewer.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "novels")
+public class Novel extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private Long contentId;
+
+    @Column(name = "thumbnail", nullable = false, length = 1000)
+    private String thumbnail;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User author;
+}

--- a/src/main/java/com/ian/novelviewer/novel/domain/NovelRepository.java
+++ b/src/main/java/com/ian/novelviewer/novel/domain/NovelRepository.java
@@ -1,0 +1,8 @@
+package com.ian.novelviewer.novel.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NovelRepository extends JpaRepository<Novel, Long> {
+}

--- a/src/main/java/com/ian/novelviewer/novel/dto/NovelDto.java
+++ b/src/main/java/com/ian/novelviewer/novel/dto/NovelDto.java
@@ -28,6 +28,17 @@ public class NovelDto {
 
         @NotNull
         private Category category;
+
+        @NotBlank
+        private String thumbnailKey;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ThumbnailResponse {
+        private String thumbnailKey;
     }
 
     @Getter

--- a/src/main/java/com/ian/novelviewer/novel/dto/NovelDto.java
+++ b/src/main/java/com/ian/novelviewer/novel/dto/NovelDto.java
@@ -1,0 +1,57 @@
+package com.ian.novelviewer.novel.dto;
+
+import com.ian.novelviewer.novel.domain.Category;
+import com.ian.novelviewer.novel.domain.Novel;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class NovelDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateNovelRequest {
+
+        @NotBlank(message = "작품명을 입력해주세요.")
+        @Size(min = 2, max = 50)
+        private String title;
+
+        @NotBlank
+        @Size(min = 2, max = 1000)
+        private String description;
+
+        @NotNull
+        private Category category;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class NovelInfoResponse {
+
+        private Long contentId;
+        private String thumbnail;
+        private String title;
+        private String description;
+        private Category category;
+        private String author;
+
+        public static NovelInfoResponse from(Novel novel) {
+            return NovelInfoResponse.builder()
+                    .contentId(novel.getContentId())
+                    .thumbnail(novel.getThumbnail())
+                    .title(novel.getTitle())
+                    .description(novel.getDescription())
+                    .category(novel.getCategory())
+                    .author(novel.getAuthor().getNickname())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/ian/novelviewer/novel/ui/NovelController.java
+++ b/src/main/java/com/ian/novelviewer/novel/ui/NovelController.java
@@ -1,0 +1,57 @@
+package com.ian.novelviewer.novel.ui;
+
+import com.ian.novelviewer.common.exception.CustomException;
+import com.ian.novelviewer.common.security.CustomUserDetails;
+import com.ian.novelviewer.novel.application.NovelService;
+import com.ian.novelviewer.novel.application.S3Service;
+import com.ian.novelviewer.novel.dto.NovelDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+import static com.ian.novelviewer.common.exception.ErrorCode.*;
+
+@RestController
+@RequestMapping("/novels")
+@RequiredArgsConstructor
+public class NovelController {
+
+    private final NovelService novelService;
+    private final S3Service s3Service;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("hasRole('AUTHOR')")
+    public ResponseEntity<?> createNovel(
+            @RequestPart("novel") @Valid NovelDto.CreateNovelRequest request,
+            @RequestPart("thumbnail") MultipartFile file,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        String imageKey = null;
+        try {
+            imageKey = s3Service.upload(file, "thumbnails");
+
+            NovelDto.NovelInfoResponse response = novelService.createNovel(request, imageKey, user);
+
+            return ResponseEntity.ok(response);
+
+        } catch (IOException e) {
+            throw new CustomException(S3_UPLOAD_FAILED);
+        } catch (Exception e) {
+            if (imageKey != null) {
+                try {
+                    s3Service.delete(imageKey);
+                } catch (Exception ex) {
+                    throw new CustomException(S3_ROLLBACK_FAILED);
+                }
+            }
+            throw new CustomException(NOVEL_CREATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/ian/novelviewer/novel/ui/NovelController.java
+++ b/src/main/java/com/ian/novelviewer/novel/ui/NovelController.java
@@ -7,6 +7,7 @@ import com.ian.novelviewer.novel.application.S3Service;
 import com.ian.novelviewer.novel.dto.NovelDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,6 +19,7 @@ import java.io.IOException;
 
 import static com.ian.novelviewer.common.exception.ErrorCode.*;
 
+@Slf4j
 @RestController
 @RequestMapping("/novels")
 @RequiredArgsConstructor
@@ -26,32 +28,36 @@ public class NovelController {
     private final NovelService novelService;
     private final S3Service s3Service;
 
-    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @PreAuthorize("hasRole('AUTHOR')")
-    public ResponseEntity<?> createNovel(
-            @RequestPart("novel") @Valid NovelDto.CreateNovelRequest request,
-            @RequestPart("thumbnail") MultipartFile file,
-            @AuthenticationPrincipal CustomUserDetails user
-    ) {
-        String imageKey = null;
-        try {
-            imageKey = s3Service.upload(file, "thumbnails");
+    private static final String S3_FOLDER_NAME = "thumbnails";
 
-            NovelDto.NovelInfoResponse response = novelService.createNovel(request, imageKey, user);
+    @PostMapping(
+            value = "/thumbnails",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    @PreAuthorize("hasRole('AUTHOR')")
+    public ResponseEntity<?> uploadThumbnail(
+            @RequestPart("thumbnail") MultipartFile file
+    ) {
+        try {
+            NovelDto.ThumbnailResponse response = s3Service.upload(file, S3_FOLDER_NAME);
 
             return ResponseEntity.ok(response);
 
         } catch (IOException e) {
+            log.error("섬네일 업로드 중 오류 발생: {}", e.getMessage());
             throw new CustomException(S3_UPLOAD_FAILED);
-        } catch (Exception e) {
-            if (imageKey != null) {
-                try {
-                    s3Service.delete(imageKey);
-                } catch (Exception ex) {
-                    throw new CustomException(S3_ROLLBACK_FAILED);
-                }
-            }
-            throw new CustomException(NOVEL_CREATION_FAILED);
         }
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('AUTHOR')")
+    public ResponseEntity<?> createNovel(
+            @RequestBody @Valid NovelDto.CreateNovelRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        NovelDto.NovelInfoResponse response = novelService.createNovel(request, user);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,9 @@ spring.jpa.database=mysql
 # jwt
 spring.jwt.token-validity-in-ms=3600000
 spring.jwt.secret-key=${JWT_SECRET_KEY}
+
+# aws
+spring.cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
+spring.cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
+spring.cloud.aws.region.static=ap-northeast-2
+spring.cloud.aws.bucket=novel-viewer-s3-uploads


### PR DESCRIPTION
## 📌 작업 내용
S3 이미지 업로드 기능을 포함한 작품 등록 기능을 구현했습니다. 

<br>

---

### ✅ 주요 구현 내용

- `Novel` 엔티티 생성
- `NovelDto` 응답 객체 작성
- `S3Service` AWS S3 이미지 업로드 및 presigned URL 생성 로직 구현
- `NovelController.createNovel` 작품 등록 API 컨트롤러 구현
    - 이미지 업로드 실패 시 롤백 처리
- 커스텀 예외 에러 코드 추가

<br>

---

### 🔧 변경 사항

**AS-IS**
- 작품 등록 기능 없음

<br>

**TO-BE**
- `/novels` 엔드포인트에서 작가 권한 사용자만 작품 등록 가능
- 썸네일 이미지 파일과 작품 정보를 함께 전송 (multipart/form-data)
- presigned URL을 통해 이미지 접근 가능
- UUID 기반 contentId 생성 후 DB 저장

<br>

---

### 🧪 테스트

- [x] **API 테스트**
  - Postman으로 `POST /novels` 요청 확인
  - 이미지 정상 업로드, DB 저장 및 응답 확인
- [ ] **테스트 코드**
  - 추후 추가 예정