### PR TITLE
Feature/novel/update delete

### DIFF
--- a/src/main/java/com/ian/novelviewer/common/exception/ErrorCode.java
+++ b/src/main/java/com/ian/novelviewer/common/exception/ErrorCode.java
@@ -6,16 +6,23 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    VALIDATION_ERROR("필드의 값이 유효한 형식이 아닙니다. 올바른 값을 입력해주세요.", HttpStatus.BAD_REQUEST),
     INVALID_CREDENTIALS("아이디 또는 비밀번호가 잘못되었습니다.", HttpStatus.UNAUTHORIZED),
     DUPLICATE_LOGIN_ID("이미 사용 중인 아이디입니다.", HttpStatus.CONFLICT),
     DUPLICATE_EMAIL("이미 가입된 이메일입니다.", HttpStatus.CONFLICT),
     USER_NOT_FOUND("사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ALREADY_HAS_ROLE("이미 해당 권한을 보유하고 있습니다.", HttpStatus.BAD_REQUEST),
-    S3_UPLOAD_FAILED("이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    S3_ROLLBACK_FAILED("이미지 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    S3_UPLOAD_FAILED("S3 업로드 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    S3_UPDATE_FAILED("S3 수정 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    S3_DELETE_FAILED("S3 삭제 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    FILE_PROCESSING_ERROR("파일을 처리하는 중 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    FILE_EMPTY("파일이 비어 있습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_FILE_FORMAT("올바른 이미지 파일 형식이 아닙니다. (jpg, png, jpeg 등)", HttpStatus.INTERNAL_SERVER_ERROR),
     NOVEL_CREATION_FAILED("작품 등록에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     NOVEL_NOT_FOUND("해당 작품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    INVALID_KEYWORD("검색어가 입력되지 않았습니다.", HttpStatus.BAD_REQUEST);
+    INVALID_KEYWORD("검색어가 입력되지 않았습니다.", HttpStatus.BAD_REQUEST),
+    NO_PERMISSION("해당 작업을 수행할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    ;
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/com/ian/novelviewer/novel/application/NovelService.java
+++ b/src/main/java/com/ian/novelviewer/novel/application/NovelService.java
@@ -13,11 +13,12 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.UUID;
 
-import static com.ian.novelviewer.common.exception.ErrorCode.INVALID_KEYWORD;
-import static com.ian.novelviewer.common.exception.ErrorCode.NOVEL_NOT_FOUND;
+import static com.ian.novelviewer.common.exception.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -25,6 +26,9 @@ import static com.ian.novelviewer.common.exception.ErrorCode.NOVEL_NOT_FOUND;
 public class NovelService {
 
     private final NovelRepository novelRepository;
+    private final S3Service s3Service;
+
+    private static final String S3_FOLDER_NAME = "thumbnails";
 
     public Page<NovelDto.NovelResponse> getAllNovels(Category category, Pageable pageable) {
         Page<Novel> novels;
@@ -51,6 +55,18 @@ public class NovelService {
     }
 
     @Transactional
+    public NovelDto.ThumbnailResponse uploadThumbnail(MultipartFile file) throws IOException {
+        log.info("섬네일 등록 처리: {}", file.getOriginalFilename());
+
+        validateFile(file);
+
+        String key = s3Service.upload(file, S3_FOLDER_NAME);
+
+        log.info("섬네일 등록 성공");
+        return NovelDto.ThumbnailResponse.builder().thumbnailKey(key).build();
+    }
+
+    @Transactional
     public NovelDto.NovelInfoResponse createNovel(
             NovelDto.CreateNovelRequest request, CustomUserDetails user
     ) {
@@ -63,13 +79,13 @@ public class NovelService {
                 Novel.builder()
                         .contentId(contentId)
                         .title(request.getTitle())
-                        .thumbnail(request.getThumbnailKey())
+                        .thumbnail(request.getThumbnail())
                         .description(request.getDescription())
                         .category(request.getCategory())
                         .author(user.getUser())
                         .build()
         );
-      
+
         log.info("작품 등록 성공");
         return NovelDto.NovelInfoResponse.from(novel);
     }
@@ -91,5 +107,92 @@ public class NovelService {
         UUID uuid = UUID.randomUUID();
 
         return Math.abs(uuid.getMostSignificantBits());
+    }
+
+    @Transactional
+    public NovelDto.NovelInfoResponse updateThumbnail(
+            Long contentId, MultipartFile file, CustomUserDetails user
+    ) throws IOException {
+        log.info("섬네일 수정 처리: {}", contentId);
+        Novel novel = findNovelOrThrow(contentId);
+
+        checkPermissionOrThrow(novel, user);
+
+        String oldKey = novel.getThumbnail();
+        String newKey = s3Service.update(file, S3_FOLDER_NAME, oldKey);
+
+        novel.changeThumbnail(newKey);
+
+        log.info("섬네일 수정 성공");
+        return NovelDto.NovelInfoResponse.from(novel);
+    }
+
+    @Transactional
+    public NovelDto.NovelInfoResponse updateNovel(
+            Long contentId, NovelDto.UpdateNovelRequest request, CustomUserDetails user
+    ) {
+        log.info("작품 수정 처리: {}", request.getTitle());
+        Novel novel = findNovelOrThrow(contentId);
+
+        checkPermissionOrThrow(novel, user);
+
+        if (StringUtils.hasText(request.getTitle())) {
+            log.info("작품명 변경: {}", request.getTitle());
+            novel.changeTitle(request.getTitle());
+        }
+
+        if (StringUtils.hasText(request.getDescription())) {
+            log.info("작품 소개 변경: {}", request.getDescription());
+            novel.changeDescription(request.getDescription());
+        }
+
+        if (request.getCategory() != null) {
+            log.info("작품 카테고리 변경: {}", request.getCategory());
+            novel.changeCategory(request.getCategory());
+        }
+
+        log.info("작품 수정 성공");
+        return NovelDto.NovelInfoResponse.from(novel);
+    }
+
+    @Transactional
+    public void deleteNovel(Long contentId, CustomUserDetails user) throws IOException {
+        log.info("작품 삭제 처리: {}", contentId);
+        Novel novel = findNovelOrThrow(contentId);
+
+        checkPermissionOrThrow(novel, user);
+
+        novelRepository.delete(novel);
+        s3Service.delete(novel.getThumbnail());
+
+        log.info("작품 삭제 성공");
+    }
+
+    private Novel findNovelOrThrow(Long contentId) {
+        return novelRepository.findByContentId(contentId)
+                .orElseThrow(() -> {
+                    log.error("존재하지 않는 작품: {}", contentId);
+                    return new CustomException(NOVEL_NOT_FOUND);
+                });
+    }
+
+    private static void checkPermissionOrThrow(Novel novel, CustomUserDetails user) {
+        if (!novel.getAuthor().getLoginId().equals(user.getUsername())) {
+            log.error("해당 작업 권한 없음 - 작가: {}, 요청자: {}",
+                    novel.getAuthor().getLoginId(), user.getUsername());
+            throw new CustomException(NO_PERMISSION);
+        }
+    }
+
+    private static void validateFile(MultipartFile file) {
+        if (file.isEmpty()) {
+            log.error("섬네일이 비어있음");
+            throw new CustomException(FILE_EMPTY);
+        }
+
+        if (!file.getContentType().startsWith("image/")) {
+            log.error("섬네일 파일의 형식이 이미지가 아님");
+            throw new CustomException(INVALID_FILE_FORMAT);
+        }
     }
 }

--- a/src/main/java/com/ian/novelviewer/novel/domain/Novel.java
+++ b/src/main/java/com/ian/novelviewer/novel/domain/Novel.java
@@ -32,4 +32,20 @@ public class Novel extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User author;
+
+    public void changeThumbnail(String thumbnail) {
+        this.thumbnail = thumbnail;
+    }
+
+    public void changeTitle(String title) {
+        this.title = title;
+    }
+
+    public void changeDescription(String description) {
+        this.description = description;
+    }
+
+    public void changeCategory(Category category) {
+        this.category = category;
+    }
 }

--- a/src/main/java/com/ian/novelviewer/novel/dto/NovelDto.java
+++ b/src/main/java/com/ian/novelviewer/novel/dto/NovelDto.java
@@ -30,9 +30,24 @@ public class NovelDto {
         private Category category;
 
         @NotBlank
-        private String thumbnailKey;
+        private String thumbnail;
     }
-  
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UpdateNovelRequest {
+
+        @Size(min = 2, max = 50)
+        private String title;
+
+        @Size(min = 2, max = 1000)
+        private String description;
+
+        private Category category;
+    }
+
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor


### PR DESCRIPTION
## 📌 작업 내용
- 작품(Novel) 및 섬네일 이미지 수정, 삭제 기능 구현
- S3 파일 수정 및 삭제 기능 구현
- 전역 예외 처리 추가

<br>

---

### ✅ 주요 구현 내용
- `NovelController`
  - 작품 수정/삭제 API 구현
  - 섬네일 수정, 삭제 API 구현
- `NovelService`
  - 작품 및 섬네일 수정/삭제 비즈니스 로직 처리
  - 파일 유효성 검사 메서드 구현
  - 작품의 작가 검증 메서드 구현
  - S3 연동
- `S3Service`
  - S3 파일 수정/삭제 구현
- `GlobalExceptionHandler`
  - 전역 예외 처리 추가 및 코드 수정

<br>

---

### 🔧 변경 사항
**AS-IS**
- 섬네일 및 작품 수정 기능 없음
- 섬네일 및 작품 삭제 기능 없음

<br>

**TO-BE**
- 섬네일 수정 가능
- 작품 수정 가능
- 섬네일 및 작품 삭제 가능

<br>

---

### 🧪 테스트
- [ ] **테스트 코드**
- [x] **API 테스트**
- Postman 테스트
  - `PATCH novels/{contentId}`
  - `PUT novels/{contentId}/thumbnails`
  - `DELETe novels/{contentId}`
  - `DELETE novels/{contentId}/thumbnails`