### PR TITLE
Feature/episode/read create

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     implementation 'software.amazon.awssdk:s3:2.31.37'
 

--- a/src/main/java/com/ian/novelviewer/common/exception/ErrorCode.java
+++ b/src/main/java/com/ian/novelviewer/common/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     NOVEL_NOT_FOUND("해당 작품을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_KEYWORD("검색어가 입력되지 않았습니다.", HttpStatus.BAD_REQUEST),
     NO_PERMISSION("해당 작업을 수행할 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    EPISODE_NOT_FOUND("해당 회차를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String message;

--- a/src/main/java/com/ian/novelviewer/common/redis/EpisodeIdService.java
+++ b/src/main/java/com/ian/novelviewer/common/redis/EpisodeIdService.java
@@ -1,0 +1,19 @@
+package com.ian.novelviewer.common.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EpisodeIdService {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final RedisTemplate redisTemplate;
+
+    public Long getNextEpisodeId(Long novelId) {
+        String key = RedisKeyUtil.episodeIdKey(novelId);
+        return redisTemplate.opsForValue().increment(key);
+    }
+}

--- a/src/main/java/com/ian/novelviewer/common/redis/RedisKeyUtil.java
+++ b/src/main/java/com/ian/novelviewer/common/redis/RedisKeyUtil.java
@@ -1,0 +1,12 @@
+package com.ian.novelviewer.common.redis;
+
+public class RedisKeyUtil {
+    private static final String PREFIX_NOVEL = "novel:";
+
+    public static String episodeIdKey(Long novelId) {
+        return PREFIX_NOVEL + "_" + novelId + "_episodeId";
+    }
+
+    private RedisKeyUtil() {
+    }
+}

--- a/src/main/java/com/ian/novelviewer/episode/application/EpisodeService.java
+++ b/src/main/java/com/ian/novelviewer/episode/application/EpisodeService.java
@@ -1,0 +1,104 @@
+package com.ian.novelviewer.episode.application;
+
+import com.ian.novelviewer.common.exception.CustomException;
+import com.ian.novelviewer.common.redis.EpisodeIdService;
+import com.ian.novelviewer.common.security.CustomUserDetails;
+import com.ian.novelviewer.episode.domain.Episode;
+import com.ian.novelviewer.episode.domain.EpisodeRepository;
+import com.ian.novelviewer.episode.dto.EpisodeDto;
+import com.ian.novelviewer.novel.domain.Novel;
+import com.ian.novelviewer.novel.domain.NovelRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import static com.ian.novelviewer.common.exception.ErrorCode.*;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EpisodeService {
+
+    private final NovelRepository novelRepository;
+    private final EpisodeRepository episodeRepository;
+    private final EpisodeIdService episodeIdService;
+
+    public Page<EpisodeDto.EpisodeTitleResponse> getAllEpisodes(Long contentId, Pageable pageable) {
+        log.info("모든 회차 조회 처리: {}", contentId);
+        Novel novel = findNovelOrThrow(contentId);
+
+        Page<Episode> episodes = episodeRepository.findByNovel(novel, pageable);
+
+        log.info("모든 회차 조회 성공");
+        return episodes.map(EpisodeDto.EpisodeTitleResponse::from);
+    }
+
+    @Transactional
+    public EpisodeDto.EpisodeInfoResponse createEpisode(
+            Long contentId, EpisodeDto.CreateEpisodeRequest request, CustomUserDetails user
+    ) {
+        log.info("회차 등록 처리: {}", request.getTitle());
+        Novel novel = findNovelOrThrow(contentId);
+
+        checkPermissionOrThrow(user, novel);
+
+        Long episodeId = episodeIdService.getNextEpisodeId(novel.getId());
+
+        Episode episode = episodeRepository.save(
+                Episode.builder()
+                        .episodeId(episodeId)
+                        .title(request.getTitle())
+                        .content(request.getContent())
+                        .novel(novel)
+                        .build()
+        );
+
+        log.info("회차 등록 성공: {}", episode.getTitle());
+        return EpisodeDto.EpisodeInfoResponse.from(episode);
+    }
+
+    public EpisodeDto.EpisodeContentResponse getEpisode(Long contentId, Long episodeId) {
+        log.info("회차 조회 처리: {}", contentId);
+        Novel novel = findNovelOrThrow(contentId);
+
+        Episode episode = findEpisodeOrThrow(episodeId);
+
+        checkEpisodeBelongsToNovelOrThrow(contentId, episodeId, episode, novel);
+
+        log.info("회차 조회 성공: {}", episode.getTitle());
+        return EpisodeDto.EpisodeContentResponse.from(episode);
+    }
+
+    private Novel findNovelOrThrow(Long contentId) {
+        return novelRepository.findByNovelId(contentId)
+                .orElseThrow(() -> {
+                    log.error("존재하지 않는 작품: {}", contentId);
+                    return new CustomException(NOVEL_NOT_FOUND);
+                });
+    }
+
+    private Episode findEpisodeOrThrow(Long episodeId) {
+        return episodeRepository.findById(episodeId)
+                .orElseThrow(() -> {
+                    log.error("존재하지 않는 회차: {}", episodeId);
+                    return new CustomException(EPISODE_NOT_FOUND);
+                });
+    }
+
+    private static void checkPermissionOrThrow(CustomUserDetails user, Novel novel) {
+        if (!novel.getAuthor().getLoginId().equals(user.getUsername())) {
+            log.error("회차 등록 권한 없음 - 작가: {}, 작성자: {}", novel.getAuthor().getLoginId(), user.getUsername());
+            throw new CustomException(NO_PERMISSION);
+        }
+    }
+
+    private static void checkEpisodeBelongsToNovelOrThrow(Long contentId, Long episodeId, Episode episode, Novel novel) {
+        if (!episode.getNovel().getNovelId().equals(novel.getNovelId())) {
+            log.error("회차가 해당 작품에 속하지 않음: episodeId={}, contentId={}", episodeId, contentId);
+            throw new CustomException(EPISODE_NOT_FOUND);
+        }
+    }
+}

--- a/src/main/java/com/ian/novelviewer/episode/domain/Episode.java
+++ b/src/main/java/com/ian/novelviewer/episode/domain/Episode.java
@@ -1,0 +1,31 @@
+package com.ian.novelviewer.episode.domain;
+
+import com.ian.novelviewer.common.base.BaseEntity;
+import com.ian.novelviewer.novel.domain.Novel;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "episodes")
+public class Episode extends BaseEntity {
+
+    @Column(nullable = false)
+    private Long episodeId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "novel_id", nullable = false)
+    private Novel novel;
+}

--- a/src/main/java/com/ian/novelviewer/episode/domain/EpisodeRepository.java
+++ b/src/main/java/com/ian/novelviewer/episode/domain/EpisodeRepository.java
@@ -1,0 +1,15 @@
+package com.ian.novelviewer.episode.domain;
+
+import com.ian.novelviewer.novel.domain.Novel;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface EpisodeRepository extends JpaRepository<Episode, Long> {
+    Page<Episode> findByNovel(Novel novel, Pageable pageable);
+}

--- a/src/main/java/com/ian/novelviewer/episode/dto/EpisodeDto.java
+++ b/src/main/java/com/ian/novelviewer/episode/dto/EpisodeDto.java
@@ -1,0 +1,71 @@
+package com.ian.novelviewer.episode.dto;
+
+import com.ian.novelviewer.episode.domain.Episode;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class EpisodeDto {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateEpisodeRequest {
+        @NotBlank
+        private String title;
+
+        @NotBlank
+        private String content;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class EpisodeTitleResponse {
+        private Long episodeId;
+        private String title;
+
+        public static EpisodeTitleResponse from(Episode episode) {
+            return EpisodeTitleResponse.builder()
+                    .episodeId(episode.getEpisodeId())
+                    .title(episode.getTitle())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class EpisodeContentResponse {
+        private String content;
+
+        public static EpisodeContentResponse from(Episode episode) {
+            return EpisodeContentResponse.builder()
+                    .content(episode.getContent())
+                    .build();
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class EpisodeInfoResponse {
+        private Long episodeId;
+        private String title;
+        private String content;
+
+        public static EpisodeInfoResponse from(Episode episode) {
+            return EpisodeInfoResponse.builder()
+                    .episodeId(episode.getEpisodeId())
+                    .title(episode.getTitle())
+                    .content(episode.getContent())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/ian/novelviewer/episode/ui/EpisodeController.java
+++ b/src/main/java/com/ian/novelviewer/episode/ui/EpisodeController.java
@@ -1,0 +1,70 @@
+package com.ian.novelviewer.episode.ui;
+
+import com.ian.novelviewer.common.security.CustomUserDetails;
+import com.ian.novelviewer.episode.application.EpisodeService;
+import com.ian.novelviewer.episode.dto.EpisodeDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/novels/{contentId}/episodes")
+@RequiredArgsConstructor
+public class EpisodeController {
+
+    private final EpisodeService episodeService;
+
+    @GetMapping
+    public ResponseEntity<?> getAllEpisodes(
+            @PathVariable Long contentId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        log.info("모든 회차 조회 요청: {}", contentId);
+        Pageable pageable = getPageable(page, size);
+
+        Page<EpisodeDto.EpisodeTitleResponse> responses = episodeService.getAllEpisodes(contentId, pageable);
+
+        log.info("모든 회차 조회 완료");
+        return ResponseEntity.ok(responses);
+    }
+
+    @PostMapping
+    @PreAuthorize("hasRole('AUTHOR')")
+    public ResponseEntity<?> createEpisode(
+            @PathVariable Long contentId,
+            @RequestBody @Valid EpisodeDto.CreateEpisodeRequest request,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        log.info("회차 등록 요청: {}", request.getTitle());
+        EpisodeDto.EpisodeInfoResponse response = episodeService.createEpisode(contentId, request, user);
+
+        log.info("회차 등록 완료: {}", response.getTitle());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{episodeId}")
+    public ResponseEntity<?> getEpisode(
+            @PathVariable Long contentId, @PathVariable Long episodeId
+    ) {
+        log.info("회차 조회 요청: {}", contentId);
+        EpisodeDto.EpisodeContentResponse response = episodeService.getEpisode(contentId, episodeId);
+
+        log.info("회차 조회 완료");
+        return ResponseEntity.ok(response);
+    }
+
+    private static Pageable getPageable(int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by("episodeId").ascending());
+        return pageable;
+    }
+}

--- a/src/main/java/com/ian/novelviewer/novel/application/NovelService.java
+++ b/src/main/java/com/ian/novelviewer/novel/application/NovelService.java
@@ -72,12 +72,12 @@ public class NovelService {
     ) {
         log.info("작품 등록 처리: {}", request.getTitle());
 
-        Long contentId = generateContentId();
-        log.info("작품 고유 번호 생성: {}", contentId);
+        Long novelId = generateNovelId();
+        log.info("작품 고유 번호 생성: {}", novelId);
 
         Novel novel = novelRepository.save(
                 Novel.builder()
-                        .contentId(contentId)
+                        .novelId(novelId)
                         .title(request.getTitle())
                         .thumbnail(request.getThumbnail())
                         .description(request.getDescription())
@@ -90,12 +90,12 @@ public class NovelService {
         return NovelDto.NovelInfoResponse.from(novel);
     }
 
-    public NovelDto.NovelInfoResponse getNovel(Long contentId) {
-        log.info("작품 조회 처리: {}", contentId);
+    public NovelDto.NovelInfoResponse getNovel(Long novelId) {
+        log.info("작품 조회 처리: {}", novelId);
 
-        Novel novel = novelRepository.findByContentId(contentId)
+        Novel novel = novelRepository.findByNovelId(novelId)
                 .orElseThrow(() -> {
-                    log.error("작품을 찾을 수 없습니다. {}", contentId);
+                    log.error("작품을 찾을 수 없습니다. {}", novelId);
                     return new CustomException(NOVEL_NOT_FOUND);
                 });
 
@@ -103,7 +103,7 @@ public class NovelService {
         return NovelDto.NovelInfoResponse.from(novel);
     }
 
-    private Long generateContentId() {
+    private Long generateNovelId() {
         UUID uuid = UUID.randomUUID();
 
         return Math.abs(uuid.getMostSignificantBits());
@@ -111,10 +111,10 @@ public class NovelService {
 
     @Transactional
     public NovelDto.NovelInfoResponse updateThumbnail(
-            Long contentId, MultipartFile file, CustomUserDetails user
+            Long novelId, MultipartFile file, CustomUserDetails user
     ) throws IOException {
-        log.info("섬네일 수정 처리: {}", contentId);
-        Novel novel = findNovelOrThrow(contentId);
+        log.info("섬네일 수정 처리: {}", novelId);
+        Novel novel = findNovelOrThrow(novelId);
 
         checkPermissionOrThrow(novel, user);
 
@@ -129,10 +129,10 @@ public class NovelService {
 
     @Transactional
     public NovelDto.NovelInfoResponse updateNovel(
-            Long contentId, NovelDto.UpdateNovelRequest request, CustomUserDetails user
+            Long novelId, NovelDto.UpdateNovelRequest request, CustomUserDetails user
     ) {
         log.info("작품 수정 처리: {}", request.getTitle());
-        Novel novel = findNovelOrThrow(contentId);
+        Novel novel = findNovelOrThrow(novelId);
 
         checkPermissionOrThrow(novel, user);
 
@@ -156,9 +156,9 @@ public class NovelService {
     }
 
     @Transactional
-    public void deleteNovel(Long contentId, CustomUserDetails user) throws IOException {
-        log.info("작품 삭제 처리: {}", contentId);
-        Novel novel = findNovelOrThrow(contentId);
+    public void deleteNovel(Long novelId, CustomUserDetails user) throws IOException {
+        log.info("작품 삭제 처리: {}", novelId);
+        Novel novel = findNovelOrThrow(novelId);
 
         checkPermissionOrThrow(novel, user);
 
@@ -168,10 +168,10 @@ public class NovelService {
         log.info("작품 삭제 성공");
     }
 
-    private Novel findNovelOrThrow(Long contentId) {
-        return novelRepository.findByContentId(contentId)
+    private Novel findNovelOrThrow(Long novelId) {
+        return novelRepository.findByNovelId(novelId)
                 .orElseThrow(() -> {
-                    log.error("존재하지 않는 작품: {}", contentId);
+                    log.error("존재하지 않는 작품: {}", novelId);
                     return new CustomException(NOVEL_NOT_FOUND);
                 });
     }

--- a/src/main/java/com/ian/novelviewer/novel/domain/Novel.java
+++ b/src/main/java/com/ian/novelviewer/novel/domain/Novel.java
@@ -14,7 +14,7 @@ import lombok.*;
 public class Novel extends BaseEntity {
 
     @Column(nullable = false, unique = true)
-    private Long contentId;
+    private Long novelId;
 
     @Column(name = "thumbnail", nullable = false, length = 1000)
     private String thumbnail;

--- a/src/main/java/com/ian/novelviewer/novel/domain/Novel.java
+++ b/src/main/java/com/ian/novelviewer/novel/domain/Novel.java
@@ -1,9 +1,13 @@
 package com.ian.novelviewer.novel.domain;
 
 import com.ian.novelviewer.common.base.BaseEntity;
+import com.ian.novelviewer.episode.domain.Episode;
 import com.ian.novelviewer.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor
@@ -32,6 +36,9 @@ public class Novel extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User author;
+
+    @OneToMany(mappedBy = "novel", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Episode> episodes = new ArrayList<>();
 
     public void changeThumbnail(String thumbnail) {
         this.thumbnail = thumbnail;

--- a/src/main/java/com/ian/novelviewer/novel/domain/NovelRepository.java
+++ b/src/main/java/com/ian/novelviewer/novel/domain/NovelRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 
 @Repository
 public interface NovelRepository extends JpaRepository<Novel, Long> {
-    Optional<Novel> findByContentId(Long contentId);
+    Optional<Novel> findByNovelId(Long contentId);
 
     Page<Novel> findAllByCategory(Category category, Pageable pageable);
 

--- a/src/main/java/com/ian/novelviewer/novel/dto/NovelDto.java
+++ b/src/main/java/com/ian/novelviewer/novel/dto/NovelDto.java
@@ -81,7 +81,7 @@ public class NovelDto {
     @Builder
     public static class NovelInfoResponse {
 
-        private Long contentId;
+        private Long novelId;
         private String thumbnail;
         private String title;
         private String description;
@@ -90,7 +90,7 @@ public class NovelDto {
 
         public static NovelInfoResponse from(Novel novel) {
             return NovelInfoResponse.builder()
-                    .contentId(novel.getContentId())
+                    .novelId(novel.getNovelId())
                     .thumbnail(novel.getThumbnail())
                     .title(novel.getTitle())
                     .description(novel.getDescription())

--- a/src/main/java/com/ian/novelviewer/novel/ui/NovelController.java
+++ b/src/main/java/com/ian/novelviewer/novel/ui/NovelController.java
@@ -84,55 +84,55 @@ public class NovelController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/{contentId}")
-    public ResponseEntity<?> getNovel(@PathVariable Long contentId) {
-        log.info("작품 조회 요청: {}", contentId);
-        NovelDto.NovelInfoResponse novel = novelService.getNovel(contentId);
+    @GetMapping("/{novelId}")
+    public ResponseEntity<?> getNovel(@PathVariable Long novelId) {
+        log.info("작품 조회 요청: {}", novelId);
+        NovelDto.NovelInfoResponse novel = novelService.getNovel(novelId);
 
         log.info("작품 조회 완료: {}", novel.getTitle());
         return ResponseEntity.ok(novel);
     }
 
     @PutMapping(
-            value = "/{contentId}/thumbnails",
+            value = "/{novelId}/thumbnails",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
     @PreAuthorize("hasRole('AUTHOR')")
     public ResponseEntity<?> updateThumbnail(
-            @PathVariable Long contentId,
+            @PathVariable Long novelId,
             @RequestParam("thumbnail") MultipartFile file,
             @AuthenticationPrincipal CustomUserDetails user
     ) throws IOException {
         log.info("섬네일 수정 요청: {}", file.getOriginalFilename());
-        NovelDto.NovelInfoResponse response = novelService.updateThumbnail(contentId, file, user);
+        NovelDto.NovelInfoResponse response = novelService.updateThumbnail(novelId, file, user);
 
         log.info("섬네일 수정 완료: {}", response.getThumbnail());
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/{contentId}")
+    @PatchMapping("/{novelId}")
     @PreAuthorize("hasRole('AUTHOR')")
     public ResponseEntity<?> updateNovel(
-            @PathVariable Long contentId,
+            @PathVariable Long novelId,
             @RequestBody NovelDto.UpdateNovelRequest request,
             @AuthenticationPrincipal CustomUserDetails user
     ) {
-        log.info("작품 수정 요청: {}", contentId);
-        NovelDto.NovelInfoResponse response = novelService.updateNovel(contentId, request, user);
+        log.info("작품 수정 요청: {}", novelId);
+        NovelDto.NovelInfoResponse response = novelService.updateNovel(novelId, request, user);
 
         log.info("작품 수정 완료: {}", response.getTitle());
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{contentId}")
+    @DeleteMapping("/{novelId}")
     @PreAuthorize("hasRole('AUTHOR')")
     public ResponseEntity<?> deleteNovel(
-            @PathVariable Long contentId,
+            @PathVariable Long novelId,
             @AuthenticationPrincipal CustomUserDetails user
     ) throws IOException {
-        log.info("작품 삭제 요청: {}", contentId);
-        novelService.deleteNovel(contentId, user);
+        log.info("작품 삭제 요청: {}", novelId);
+        novelService.deleteNovel(novelId, user);
 
         log.info("작품 삭제 성공");
         return ResponseEntity.ok("작품 삭제에 성공했습니다.");

--- a/src/main/java/com/ian/novelviewer/novel/ui/NovelController.java
+++ b/src/main/java/com/ian/novelviewer/novel/ui/NovelController.java
@@ -126,7 +126,7 @@ public class NovelController {
     }
 
     @DeleteMapping("/{novelId}")
-    @PreAuthorize("hasRole('AUTHOR')")
+    @PreAuthorize("hasAnyRole('AUTHOR', 'ADMIN')")
     public ResponseEntity<?> deleteNovel(
             @PathVariable Long novelId,
             @AuthenticationPrincipal CustomUserDetails user

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,7 @@ spring.cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 spring.cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 spring.cloud.aws.region.static=ap-northeast-2
 spring.cloud.aws.bucket=novel-viewer-s3-uploads
+
+# redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379


### PR DESCRIPTION
## 📌 작업 내용  
- 회차(Episode) 등록/조회 API 개발
- Redis 기반의 회차 번호 자동 증가 기능 구현

---

### ✅ 주요 구현 내용
- `EpisodeController`
  - 회차 등록 API 구현 (`POST /novels/{novelId}/episodes`)
  - 모든 회차 조회(제목) API 구현 (`GET /novels/{novelId}/episodes`)
  - 회차 조회(내용) API 구현 (`POST /novels/{novelId}/episodes/{episodeId}`)
- `EpisodeService`
  - 회차 등록/조회 비즈니스 로직 구현 (`getAllEpisode`, `createEpisode`, `getEpisode`)
- `EpisodeIdService`
  - 각 작품 별 회차 ID를 생성하는 로직 구현 (`getNextEpisodeId`)

---

### 🔧 변경 사항  
**AS-IS**  
- 회차 등록 API가 없음
- 회차 조회 API가 없음
- Redis 미사용

<br>

**TO-BE**
- 회차 등록 가능
- 회차 조회 가능
- Redis로 작품 별 `episodeId` 시퀀스 관리  

---

### 🧪 테스트  
- [x] **API 테스트**  
- 
- [ ] **테스트 코드**  
- 추후 추가 예정

---

### ⚙️ 설정 파일
**build.gradle**
```
implementation 'org.springframework.boot:spring-boot-starter-data-redis'
```
**application.properties**
```
spring.data.redis.host=localhost
spring.data.redis.port=6379
```